### PR TITLE
Fix #5 - typeCoverage config to support atLeast

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,15 @@ To set the minimum threshold _(80% by default)_, use the `--threshold` option.
 $ yarn ts-coverage --threshold=99
 ```
 
-As an alternative, options may be provided through the `type-coverage` [configuration](https://github.com/plantain-00/type-coverage#config-in-packagejson), specified in `package.json`.
+As an alternative, ~~options~~\* `atLeast` may be provided through the `type-coverage` [configuration](https://github.com/plantain-00/type-coverage#config-in-packagejson), specified in `package.json`.
 
 ```json
 "typeCoverage": {
   "atLeast": 90
 }
 ```
+
+<super>\*</super> At this time, only `atLeast` is supported. Please feel free to contribute 🤘
 
 ![terminal table](docs/screenshot-table.png)
 

--- a/src/bin/typescript-coverage-report.ts
+++ b/src/bin/typescript-coverage-report.ts
@@ -1,15 +1,41 @@
 #!/usr/bin/env node
 
 import { program } from "commander";
+import * as fs from "fs";
+import * as path from "path";
 import generateCoverageReport from "../lib";
 import getOptions from "../lib/getOptions";
 
 const {
   version,
-  description,
-  typeCoverage = {}
+  description
   // eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require("../../package.json");
+
+/**
+ * Sets a default coverage threshold of `80`.
+ * If user provides `atLeast` in their `typeCoverage` configuration in
+ * their package.json, we set that as the program's default instead.
+ */
+const getAtLeast = () => {
+  let atLeast = 80;
+
+  const packageJsonPath = path.resolve(process.cwd(), "package.json");
+
+  if (fs.existsSync(packageJsonPath)) {
+    const currentPackageJson: {
+      typeCoverage?: {
+        atLeast?: number;
+      };
+    } = JSON.parse(fs.readFileSync(packageJsonPath).toString());
+
+    if (currentPackageJson.typeCoverage?.atLeast) {
+      atLeast = currentPackageJson.typeCoverage.atLeast;
+    }
+  }
+
+  return atLeast;
+};
 
 const argvWithVersion = (argvs: string[]): string[] => {
   const vPos = argvs.indexOf("-v");
@@ -33,7 +59,7 @@ program
     "-t, --threshold [number]",
     "The minimum percentage of coverage required.",
     parseFloat,
-    typeCoverage.atLeast || 80
+    getAtLeast()
   )
   .option("-s, --strict [boolean]", "Run the check in strict mode.", false)
   .option("-d, --debug [boolean]", "Show debug information.", false)


### PR DESCRIPTION
Please see this issue for details: #5 

A user's locally provided `typeCoverage` object would not be recognized, I took an approach very similar to what `type-coverage` itself [did](https://github.com/plantain-00/type-coverage/blob/5ad7db06e7c026f3c3a29bed6812dec01e40855b/packages/cli/src/index.ts#L67).

It differs in just a variety of ways:
- uses the sync versions of exists/readFile
- syntactic sugar of optional chaining 😇

Edit:
Was able to test this using `yarn link` and running `yarn build --watch` with a separate project that was using this package. Perhaps it might be helpful to add directions or suggestions on how to develop and contribute? 