### PR TITLE
Make the summary table sortable

### DIFF
--- a/src/components/SummaryPage/SummaryPage.tsx
+++ b/src/components/SummaryPage/SummaryPage.tsx
@@ -44,7 +44,7 @@ const SummaryPage = ({
         </Table.Body>
       </Table>
       <Header as="h2">Files</Header>
-      <Table celled style={{ marginTop: "2em" }}>
+      <Table celled style={{ marginTop: "2em" }} className="sortable">
         <Table.Header>
           <Table.Row>
             {headers.map((header, index) => (

--- a/src/components/SummaryPage/__tests__/__snapshots__/SummaryPage.test.tsx.snap
+++ b/src/components/SummaryPage/__tests__/__snapshots__/SummaryPage.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`SummaryPage component renders correctly 1`] = `
     Files
   </h2>
   <table
-    class="ui celled table"
+    class="ui celled table sortable"
     style="margin-top: 2em;"
   >
     <thead

--- a/src/lib/reporters/html.ts
+++ b/src/lib/reporters/html.ts
@@ -91,7 +91,10 @@ export const generate = async (
       threshold: options.threshold
     },
     {
-      assets: includeAssets(["./assets/source-file.css"])
+      assets: includeAssets([
+        "./assets/source-file.css",
+        "https://cdn.jsdelivr.net/npm/sorttable@1.0.2/sorttable.min.js"
+      ])
     }
   );
 


### PR DESCRIPTION
This uses the venerable [sorttable](https://www.kryogenix.org/code/browser/sorttable/) library to make the columns in the summary table sortable. In particular in makes it possible to sort by uncovered expressions, which is almost always what you want:

![sort-by-uncovered](https://user-images.githubusercontent.com/98301/98747027-ad97e400-2384-11eb-994e-54014ec73679.gif)
