### PR TITLE
Delete output directory just before generating it

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,10 +21,6 @@ export default async function generateCoverageReport(
   // NOTE: Cleanup the folder
   const dirPath = path.join(process.cwd(), options.outputDir);
 
-  if (fs.existsSync(dirPath)) {
-    rimraf.sync(dirPath);
-  }
-
   const data = await getCoverage({
     strict: options.strict,
     debug: options.debug,
@@ -36,6 +32,10 @@ export default async function generateCoverageReport(
 
   console.log(generateText(data, options.threshold));
 
+  if (fs.existsSync(dirPath)) {
+    rimraf.sync(dirPath);
+  }
+  
   await generateHTML(data, options);
   await asyncNcp(
     path.join(__dirname, "../../assets"),


### PR DESCRIPTION
Hello 👋 

The report data collection & generation may take seconds to minutes.

I noticed that as soon as I trigger the coverage command, I am unable to navigate the previous report because it gets deleted.

This change delays the deletion of the file to just before generating the HTML report, allowing developers to explore the previous report while a new one is being generated.

Thank you 💜 