### PR TITLE
feat: allow project path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The CLI accepts a list of arguments:
 | `-s, --strict [boolean]`        | Run the check in strict mode.                                                          | false         |
 | `-d, --debug [boolean]`         | Show debug information.                                                                | false         |
 | `-c, --cache [boolean]`         | Save and reuse type check result from cache.                                           | false         |
+| `-p, --project [string]`        | File path to tsconfig file, eg: --project "./app/tsconfig.app.json"                    | .             |
 | `-i, --ignore-files [boolean]`  | Ignore specified files, eg: --ignore-files "demo1/\*.ts" --ignore-files "demo2/foo.ts" | false         |
 | `-u, --ignore-unread [boolean]` | Allow writes to variables with implicit any types                                      | false         |
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "type-coverage": "node ./dist/bin/typescript-coverage-report",
     "docs": "yarn type-coverage --outputDir docs",
     "prepublish": "yarn lint && yarn build",
+    "test": "jest",
     "release": "gren release"
   },
   "devDependencies": {

--- a/src/bin/typescript-coverage-report.ts
+++ b/src/bin/typescript-coverage-report.ts
@@ -31,6 +31,7 @@ const {
   strict = false,
   debug = false,
   cache = false,
+  project = ".",
   ignoreFiles = false,
   ignoreCatch = false,
   ignoreUnread = false
@@ -58,6 +59,11 @@ program
     cache
   )
   .option(
+    "-p, --project [string]",
+    'file path to tsconfig file, eg: --project "./app/tsconfig.app.json"',
+    project
+  )
+  .option(
     "-i, --ignore-files [string[]]",
     'ignore specified files, eg: --ignore-files "demo1/*.ts" --ignore-files "demo2/foo.ts"',
     ignoreFiles
@@ -78,6 +84,7 @@ const options = {
   /* camelCase keys matching "long" flags in options above */
   outputDir: program.outputDir,
   threshold: program.threshold,
+  tsProjectFile: program.project,
   strict: program.strict,
   debug: program.debug,
   cache: program.cache,

--- a/src/lib/__tests__/__snapshots__/getCoverage.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/getCoverage.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getCoverage function default project root is passed in 1`] = `
+exports[`getCoverage function accepts a tsProjectFile option 1`] = `
 Object {
   "anys": Array [],
   "covered": 100,
@@ -16,87 +16,41 @@ Object {
 }
 `;
 
-exports[`getCoverage function default project root is passed into lint function 1`] = `
-Object {
-  "anys": Array [],
-  "covered": 100,
-  "fileCounts": Map {
-    "index.html" => Object {
-      "correctCount": 100,
-      "totalCount": 100,
+exports[`getCoverage function accepts a tsProjectFile option 2`] = `
+Array [
+  Array [
+    "./app/tsconfig.json",
+    Object {
+      "debug": undefined,
+      "enableCache": undefined,
+      "fileCounts": true,
+      "ignoreCatch": undefined,
+      "ignoreFiles": undefined,
+      "ignoreUnreadAnys": undefined,
+      "strict": undefined,
     },
-  },
-  "percentage": 100,
-  "total": 100,
-  "uncovered": 0,
-}
+  ],
+]
 `;
 
-exports[`getCoverage function project is passed into lint function 1`] = `
-Object {
-  "anys": Array [],
-  "covered": 100,
-  "fileCounts": Map {
-    "index.html" => Object {
-      "correctCount": 100,
-      "totalCount": 100,
+exports[`getCoverage function defaults to root project when tsProjectFile is not passed 1`] = `
+Array [
+  Array [
+    ".",
+    Object {
+      "debug": undefined,
+      "enableCache": undefined,
+      "fileCounts": true,
+      "ignoreCatch": undefined,
+      "ignoreFiles": undefined,
+      "ignoreUnreadAnys": undefined,
+      "strict": undefined,
     },
-  },
-  "percentage": 100,
-  "total": 100,
-  "uncovered": 0,
-}
+  ],
+]
 `;
 
 exports[`getCoverage function returns calculated data from type-coverage-core 1`] = `
-Object {
-  "anys": Array [],
-  "covered": 100,
-  "fileCounts": Map {
-    "index.html" => Object {
-      "correctCount": 100,
-      "totalCount": 100,
-    },
-  },
-  "percentage": 100,
-  "total": 100,
-  "uncovered": 0,
-}
-`;
-
-exports[`getCoverage function returns calculated data from type-coverage-core 2`] = `
-Object {
-  "anys": Array [],
-  "covered": 100,
-  "fileCounts": Map {
-    "index.html" => Object {
-      "correctCount": 100,
-      "totalCount": 100,
-    },
-  },
-  "percentage": 100,
-  "total": 100,
-  "uncovered": 0,
-}
-`;
-
-exports[`getCoverage function tsProjectFile is passed into lint function 1`] = `
-Object {
-  "anys": Array [],
-  "covered": 100,
-  "fileCounts": Map {
-    "index.html" => Object {
-      "correctCount": 100,
-      "totalCount": 100,
-    },
-  },
-  "percentage": 100,
-  "total": 100,
-  "uncovered": 0,
-}
-`;
-
-exports[`getCoverage function tsProjectFile is passed into lint function, if provided 1`] = `
 Object {
   "anys": Array [],
   "covered": 100,

--- a/src/lib/__tests__/__snapshots__/getCoverage.test.ts.snap
+++ b/src/lib/__tests__/__snapshots__/getCoverage.test.ts.snap
@@ -1,6 +1,102 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getCoverage function default project root is passed in 1`] = `
+Object {
+  "anys": Array [],
+  "covered": 100,
+  "fileCounts": Map {
+    "index.html" => Object {
+      "correctCount": 100,
+      "totalCount": 100,
+    },
+  },
+  "percentage": 100,
+  "total": 100,
+  "uncovered": 0,
+}
+`;
+
+exports[`getCoverage function default project root is passed into lint function 1`] = `
+Object {
+  "anys": Array [],
+  "covered": 100,
+  "fileCounts": Map {
+    "index.html" => Object {
+      "correctCount": 100,
+      "totalCount": 100,
+    },
+  },
+  "percentage": 100,
+  "total": 100,
+  "uncovered": 0,
+}
+`;
+
+exports[`getCoverage function project is passed into lint function 1`] = `
+Object {
+  "anys": Array [],
+  "covered": 100,
+  "fileCounts": Map {
+    "index.html" => Object {
+      "correctCount": 100,
+      "totalCount": 100,
+    },
+  },
+  "percentage": 100,
+  "total": 100,
+  "uncovered": 0,
+}
+`;
+
 exports[`getCoverage function returns calculated data from type-coverage-core 1`] = `
+Object {
+  "anys": Array [],
+  "covered": 100,
+  "fileCounts": Map {
+    "index.html" => Object {
+      "correctCount": 100,
+      "totalCount": 100,
+    },
+  },
+  "percentage": 100,
+  "total": 100,
+  "uncovered": 0,
+}
+`;
+
+exports[`getCoverage function returns calculated data from type-coverage-core 2`] = `
+Object {
+  "anys": Array [],
+  "covered": 100,
+  "fileCounts": Map {
+    "index.html" => Object {
+      "correctCount": 100,
+      "totalCount": 100,
+    },
+  },
+  "percentage": 100,
+  "total": 100,
+  "uncovered": 0,
+}
+`;
+
+exports[`getCoverage function tsProjectFile is passed into lint function 1`] = `
+Object {
+  "anys": Array [],
+  "covered": 100,
+  "fileCounts": Map {
+    "index.html" => Object {
+      "correctCount": 100,
+      "totalCount": 100,
+    },
+  },
+  "percentage": 100,
+  "total": 100,
+  "uncovered": 0,
+}
+`;
+
+exports[`getCoverage function tsProjectFile is passed into lint function, if provided 1`] = `
 Object {
   "anys": Array [],
   "covered": 100,

--- a/src/lib/__tests__/getCoverage.test.ts
+++ b/src/lib/__tests__/getCoverage.test.ts
@@ -1,3 +1,4 @@
+import typeCoverageCore from "type-coverage-core";
 import getCoverage from "../getCoverage";
 
 describe("getCoverage function", () => {
@@ -6,6 +7,44 @@ describe("getCoverage function", () => {
 
     expect(data).toMatchSnapshot();
 
+    done();
+  });
+
+  it("tsProjectFile is passed into lint function, if provided", async (done) => {
+    typeCoverageCore.lint = jest.fn().mockImplementation(typeCoverageCore.lint);
+
+    const data = await getCoverage({
+      tsProjectFile: "./app/tsconfig.json"
+    });
+
+    expect(data).toMatchSnapshot();
+    expect(typeCoverageCore.lint).toHaveBeenCalledWith("./app/tsconfig.json", {
+      debug: undefined,
+      enableCache: undefined,
+      fileCounts: true,
+      ignoreCatch: undefined,
+      ignoreFiles: undefined,
+      ignoreUnreadAnys: undefined,
+      strict: undefined
+    });
+    done();
+  });
+
+  it("default project root is passed into lint function", async (done) => {
+    typeCoverageCore.lint = jest.fn().mockImplementation(typeCoverageCore.lint);
+
+    const data = await getCoverage();
+
+    expect(data).toMatchSnapshot();
+    expect(typeCoverageCore.lint).toHaveBeenCalledWith(".", {
+      debug: undefined,
+      enableCache: undefined,
+      fileCounts: true,
+      ignoreCatch: undefined,
+      ignoreFiles: undefined,
+      ignoreUnreadAnys: undefined,
+      strict: undefined
+    });
     done();
   });
 });

--- a/src/lib/__tests__/getCoverage.test.ts
+++ b/src/lib/__tests__/getCoverage.test.ts
@@ -2,6 +2,10 @@ import typeCoverageCore from "type-coverage-core";
 import getCoverage from "../getCoverage";
 
 describe("getCoverage function", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns calculated data from type-coverage-core", async (done) => {
     const data = await getCoverage();
 
@@ -10,7 +14,7 @@ describe("getCoverage function", () => {
     done();
   });
 
-  it("tsProjectFile is passed into lint function, if provided", async (done) => {
+  it("accepts a tsProjectFile option", async (done) => {
     typeCoverageCore.lint = jest.fn().mockImplementation(typeCoverageCore.lint);
 
     const data = await getCoverage({
@@ -18,33 +22,18 @@ describe("getCoverage function", () => {
     });
 
     expect(data).toMatchSnapshot();
-    expect(typeCoverageCore.lint).toHaveBeenCalledWith("./app/tsconfig.json", {
-      debug: undefined,
-      enableCache: undefined,
-      fileCounts: true,
-      ignoreCatch: undefined,
-      ignoreFiles: undefined,
-      ignoreUnreadAnys: undefined,
-      strict: undefined
-    });
+    // @ts-expect-error
+    expect(typeCoverageCore.lint.mock.calls).toMatchSnapshot();
     done();
   });
 
-  it("default project root is passed into lint function", async (done) => {
+  it("defaults to root project when tsProjectFile is not passed", async (done) => {
     typeCoverageCore.lint = jest.fn().mockImplementation(typeCoverageCore.lint);
 
-    const data = await getCoverage();
+    await getCoverage();
 
-    expect(data).toMatchSnapshot();
-    expect(typeCoverageCore.lint).toHaveBeenCalledWith(".", {
-      debug: undefined,
-      enableCache: undefined,
-      fileCounts: true,
-      ignoreCatch: undefined,
-      ignoreFiles: undefined,
-      ignoreUnreadAnys: undefined,
-      strict: undefined
-    });
+    // @ts-expect-error
+    expect(typeCoverageCore.lint.mock.calls).toMatchSnapshot();
     done();
   });
 });

--- a/src/lib/getCoverage.ts
+++ b/src/lib/getCoverage.ts
@@ -31,7 +31,7 @@ export type Options = Partial<
 
 const getCoverage = async (options?: Options): Promise<CoverageData> => {
   const {
-    tsProjectFile,
+    tsProjectFile = ".",
     strict,
     debug,
     ignoreFiles,
@@ -40,9 +40,8 @@ const getCoverage = async (options?: Options): Promise<CoverageData> => {
     ignoreUnread: ignoreUnreadAnys
   } = options || {};
 
-  const projectPath = tsProjectFile || ".";
   const { anys, fileCounts, totalCount, correctCount } = await lint(
-    projectPath,
+    tsProjectFile,
     {
       strict,
       debug,

--- a/src/lib/getCoverage.ts
+++ b/src/lib/getCoverage.ts
@@ -20,7 +20,10 @@ export type CoverageData = {
 };
 
 export type Options = Partial<
-  Pick<LintOptions, "strict" | "debug" | "ignoreFiles" | "ignoreCatch"> & {
+  Pick<
+    LintOptions,
+    "strict" | "debug" | "ignoreFiles" | "ignoreCatch" | "tsProjectFile"
+  > & {
     cache: LintOptions["enableCache"];
     ignoreUnread: LintOptions["ignoreUnreadAnys"];
   }
@@ -28,6 +31,7 @@ export type Options = Partial<
 
 const getCoverage = async (options?: Options): Promise<CoverageData> => {
   const {
+    tsProjectFile,
     strict,
     debug,
     ignoreFiles,
@@ -36,15 +40,19 @@ const getCoverage = async (options?: Options): Promise<CoverageData> => {
     ignoreUnread: ignoreUnreadAnys
   } = options || {};
 
-  const { anys, fileCounts, totalCount, correctCount } = await lint(".", {
-    strict,
-    debug,
-    ignoreFiles,
-    ignoreCatch,
-    enableCache,
-    ignoreUnreadAnys,
-    fileCounts: true
-  });
+  const projectPath = tsProjectFile || ".";
+  const { anys, fileCounts, totalCount, correctCount } = await lint(
+    projectPath,
+    {
+      strict,
+      debug,
+      ignoreFiles,
+      ignoreCatch,
+      enableCache,
+      ignoreUnreadAnys,
+      fileCounts: true
+    }
+  );
   const percentage = totalCount === 0 ? 100 : (correctCount * 100) / totalCount;
 
   return {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -22,6 +22,7 @@ export default async function generateCoverageReport(
   const dirPath = path.join(process.cwd(), options.outputDir);
 
   const data = await getCoverage({
+    tsProjectFile: options.tsProjectFile,
     strict: options.strict,
     debug: options.debug,
     ignoreFiles: options.ignoreFiles,


### PR DESCRIPTION
This PR allows for the tsconfig.json path to be passed in, using the same argument structure as `plantain-00/type-coverage` (https://github.com/plantain-00/type-coverage#arguments).

Thanks!