### PR TITLE
deps: pin typescript to 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "semantic-ui-react": "^0.88.2",
     "terminal-table": "^0.0.12",
     "type-coverage-core": "^2.17.2",
-    "typescript": "^4.1.3"
+    "typescript": "4.1.3"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Fixed: #78 
Pin typescript to 4.1.3