### PR TITLE
fix(dependencies): move ts to devDeps and add it to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "rimraf": "^3.0.2",
     "semantic-ui-react": "^0.88.2",
     "terminal-table": "^0.0.12",
-    "type-coverage-core": "^2.17.2",
-    "typescript": "4.1.3"
+    "type-coverage-core": "^2.17.2"
   },
   "scripts": {
     "build": "tsc",
@@ -57,7 +56,11 @@
     "husky": "^4.2.3",
     "jest": "^25.1.0",
     "lint-staged": "^10.0.8",
-    "prettier": "^2.0.2"
+    "prettier": "^2.0.2",
+    "typescript": "4.1.3"
+  },
+  "peerDependencies": {
+    "typescript": "2 || 3 || 4"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Right now when trying to generate coverage report `type-coverage-core` will use the same TS version, which specified in `package.json` of this tool, this might cause errors if user uses higher/lower version of typescript and they have some deprecated/new options in tsconfig, or features in ts files themselves. This tool should use whatever typescript version user uses for coverage report, hence we need to move ts to `devDependencies` and add it to `peerDependencies`, same range as https://github.com/plantain-00/type-coverage/blob/master/packages/core/package.json#L21 (I haven't tested, but assume that it can work with all those versions).