### PR TITLE
Upgrade typescript to 4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lint-staged": "^10.0.8",
     "package-json-type": "^1.0.3",
     "prettier": "^2.0.2",
-    "typescript": "4.1.3"
+    "typescript": "4.5.4"
   },
   "peerDependencies": {
     "typescript": "2 || 3 || 4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8206,10 +8206,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 uid-number@0.0.6:
   version "0.0.6"


### PR DESCRIPTION
TypeScript 4.5 added a new flag `preserveValueImports`﻿ (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html)

Currently, without upgrading TS, the package throws the following error:

```js
[
  {
    file: undefined,
    start: undefined,
    length: undefined,
    messageText: "Unknown compiler option 'preserveValueImports'.",
    category: 1,
    code: 5023,
    reportsUnnecessary: undefined,
    reportsDeprecated: undefined
  }
]
```
