### PR TITLE
Renamed default output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 dist/
 coverage/
-coverage-ts/
+typescript-coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 #tests
 coverage
-coverage-ts
+typescript-coverage
 
 #linters
 .eslintrc.js

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The CLI accepts a list of arguments:
 | Option                          | Description                                                                            | Default value |
 | ------------------------------- | -------------------------------------------------------------------------------------- | ------------- |
 | `-t, --threshold [number]`      | The minimum percentage of coverage required.                                           | 80            |
-| `-o, --outputDir [string]`      | The output directory where to generate the report.                                     | coverage-ts   |
+| `-o, --outputDir [string]`      | The output directory where to generate the report.                                     | typescript-coverage   |
 | `-s, --strict [boolean]`        | Run the check in strict mode.                                                          | false         |
 | `-d, --debug [boolean]`         | Show debug information.                                                                | false         |
 | `-c, --cache [boolean]`         | Save and reuse type check result from cache.                                           | false         |

--- a/docs/files/src/bin/typescript-coverage-report.ts.html
+++ b/docs/files/src/bin/typescript-coverage-report.ts.html
@@ -55,7 +55,7 @@ const argvWithVersion = (argvs: string[]): string[] =&gt; {
 };
 
 const {
-  outputDir = &quot;coverage-ts&quot;,
+  outputDir = &quot;typescript-coverage&quot;,
   atLeast = 80,
   strict = false,
   debug = false,

--- a/src/bin/typescript-coverage-report.ts
+++ b/src/bin/typescript-coverage-report.ts
@@ -42,7 +42,7 @@ const argvWithVersion = (argvs: string[]): string[] => {
 };
 
 const {
-  outputDir = "coverage-ts",
+  outputDir = "typescript-coverage",
   atLeast = 80,
   strict = false,
   debug = false,


### PR DESCRIPTION
`typescript-coverage` seems to be a more clear default choice, especially for teams with multiple coverage outputs like `unit-coverage`, `integration-coverage`, etc.

What do you think?