### PR TITLE
fix(json-generator): fileCounts not getting emitted into json

### DIFF
--- a/src/lib/reporters/__tests__/json.test.ts
+++ b/src/lib/reporters/__tests__/json.test.ts
@@ -1,0 +1,65 @@
+import { generate } from "../json";
+import fs from "fs";
+import path from "path";
+import { CoverageData } from "../../getCoverage";
+
+const fsMocked = fs.promises as jest.Mocked<typeof fs.promises>;
+jest.mock("fs", () => ({
+  promises: {
+    writeFile: jest.fn().mockResolvedValue(undefined)
+  }
+}));
+
+describe("generate function", () => {
+  const coverageData: CoverageData = {
+    fileCounts: new Map([
+      ["file1.ts", { correctCount: 10, totalCount: 15 }],
+      ["file2.ts", { correctCount: 5, totalCount: 5 }]
+    ]),
+    anys: [{ file: "file1.ts", character: 1, kind: 1, line: 2, text: "test" }],
+    percentage: 75,
+    total: 20,
+    covered: 15,
+    uncovered: 5
+  };
+
+  const options = {
+    outputDir: "./coverage",
+    threshold: 80
+  };
+
+  it("writes the correct file with serialized coverage data", async () => {
+    await generate(coverageData, options);
+
+    const expectedFilePath = path.join(
+      options.outputDir,
+      "typescript-coverage.json"
+    );
+    expect(fsMocked.writeFile).toHaveBeenCalledWith(
+      expectedFilePath,
+      expect.any(String)
+    );
+    expect(JSON.parse(fsMocked.writeFile.mock.calls[0][1])).toMatchObject({
+      fileCounts: {
+        "file1.ts": {
+          correctCount: expect.any(Number),
+          totalCount: expect.any(Number)
+        },
+        "file2.ts": expect.any(Object)
+      },
+      anys: [
+        {
+          file: expect.any(String),
+          character: expect.any(Number),
+          kind: expect.any(Number),
+          line: expect.any(Number),
+          text: expect.any(String)
+        }
+      ],
+      percentage: expect.any(Number),
+      total: expect.any(Number),
+      covered: expect.any(Number),
+      uncovered: expect.any(Number)
+    });
+  });
+});

--- a/src/lib/reporters/json.ts
+++ b/src/lib/reporters/json.ts
@@ -1,21 +1,28 @@
 import { CoverageData } from "../getCoverage";
 import fs from "fs";
 import path from "path";
-import { promisify } from "util";
 
 type Options = {
   outputDir: string;
   threshold: number;
 };
 
-const writeFile = promisify(fs.writeFile);
-
 export const generate = async (
   coverageData: CoverageData,
   options?: Options
 ): Promise<void> => {
-  await writeFile(
+  // Maps cannot be serialized in JSON.stringify
+  const serializableFileCounts = Object.fromEntries(coverageData.fileCounts);
+
+  await fs.promises.writeFile(
     path.join(options.outputDir, "typescript-coverage.json"),
-    JSON.stringify(coverageData, null, 2)
+    JSON.stringify(
+      {
+        ...coverageData,
+        fileCounts: serializableFileCounts
+      },
+      null,
+      2
+    )
   );
 };


### PR DESCRIPTION
### Background
According to this report #72 `fileCounts` was not getting outputted into the JSON type due to the input type to the serializer being JSON. The reasoning for this `Maps` in javascript when serialized through `JSON.stringify` are converted into `{}`. 

### Solution
Run `JSON.fromEntries` on `fileCounts` before serializing. Also, added a unit test to ensure the output works and prevent future regressions.

