### PR TITLE
chore: emit TS declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
+    "declaration": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Currently, this library only publishes the compiled `.js` files to npm, so there is no easy way for users to access type-defintions like `CoverageData`: 

https://github.com/alexcanessa/typescript-coverage-report/blob/ae28737ed4c9c37e581810281b7acf7cd578323d/src/lib/getCoverage.ts#L13-L20

If this MR is accepted, the generated `.d.ts` files will also be published to npm, which would make it more convinient to access these typedefs